### PR TITLE
Added support for amazon linux 2015.03

### DIFF
--- a/attributes/mysql55-community.rb
+++ b/attributes/mysql55-community.rb
@@ -14,6 +14,8 @@ when 'rhel'
       default['yum']['mysql55-community']['baseurl'] = 'http://repo.mysql.com/yum/mysql-5.5-community/el/6/$basearch/'
     when 2014
       default['yum']['mysql55-community']['baseurl'] = 'http://repo.mysql.com/yum/mysql-5.5-community/el/6/$basearch/'
+    when 2015
+      default['yum']['mysql55-community']['baseurl'] = 'http://repo.mysql.com/yum/mysql-5.5-community/el/6/$basearch/'
     end
   when 'redhat'
     case node['platform_version'].to_i


### PR DESCRIPTION
A new amazon linux version is out which breaks the support with this cookbook. 
Support is added for the amazon linux version 2015.03