### PR TITLE
Added support for Amazon Linux AMI 2016.03

### DIFF
--- a/attributes/mysql-connectors-community.rb
+++ b/attributes/mysql-connectors-community.rb
@@ -16,6 +16,8 @@ when 'rhel'
       default['yum']['mysql-connectors-community']['baseurl'] = 'http://repo.mysql.com/yum/mysql-connectors-community/el/6/$basearch/'
     when 2015
       default['yum']['mysql-connectors-community']['baseurl'] = 'http://repo.mysql.com/yum/mysql-connectors-community/el/6/$basearch/'
+    when 2016
+      default['yum']['mysql-connectors-community']['baseurl'] = 'http://repo.mysql.com/yum/mysql-connectors-community/el/6/$basearch/'
     end
   when 'redhat'
     case node['platform_version'].to_i

--- a/attributes/mysql55-community.rb
+++ b/attributes/mysql55-community.rb
@@ -16,6 +16,8 @@ when 'rhel'
       default['yum']['mysql55-community']['baseurl'] = 'http://repo.mysql.com/yum/mysql-5.5-community/el/6/$basearch/'
     when 2015
       default['yum']['mysql55-community']['baseurl'] = 'http://repo.mysql.com/yum/mysql-5.5-community/el/6/$basearch/'
+    when 2016
+      default['yum']['mysql55-community']['baseurl'] = 'http://repo.mysql.com/yum/mysql-5.5-community/el/6/$basearch/'
     end
   when 'redhat'
     case node['platform_version'].to_i

--- a/attributes/mysql56-community.rb
+++ b/attributes/mysql56-community.rb
@@ -16,6 +16,8 @@ when 'rhel'
       default['yum']['mysql56-community']['baseurl'] = 'http://repo.mysql.com/yum/mysql-5.6-community/el/6/$basearch/'
     when 2015
       default['yum']['mysql56-community']['baseurl'] = 'http://repo.mysql.com/yum/mysql-5.6-community/el/6/$basearch/'
+    when 2016
+      default['yum']['mysql56-community']['baseurl'] = 'http://repo.mysql.com/yum/mysql-5.6-community/el/6/$basearch/'
     end
   when 'redhat'
     case node['platform_version'].to_i

--- a/attributes/mysql57-community.rb
+++ b/attributes/mysql57-community.rb
@@ -16,6 +16,8 @@ when 'rhel'
       default['yum']['mysql57-community']['baseurl'] = 'http://repo.mysql.com/yum/mysql-5.7-community/el/6/$basearch/'
     when 2015
       default['yum']['mysql57-community']['baseurl'] = 'http://repo.mysql.com/yum/mysql-5.7-community/el/6/$basearch/'
+    when 2016
+      default['yum']['mysql57-community']['baseurl'] = 'http://repo.mysql.com/yum/mysql-5.7-community/el/6/$basearch/'
     end
   when 'redhat'
     case node['platform_version'].to_i


### PR DESCRIPTION
A new version of Amazon Linux AMI has been released.
https://aws.amazon.com/amazon-linux-ami/2016.03-release-notes/

This commit contains support for platform_versions of 2016.