### PR TITLE
Fix oracle linux repo urls

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -28,6 +28,10 @@ platforms:
   driver:
     image: centos:7
 
+- name: oracle-7
+  driver:
+    image: oraclelinux:7
+
 suites:
 - name: connectors
   run_list:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ env:
   - INSTANCE=connectors-centos-7
   - INSTANCE=mysql56-centos-7
   - INSTANCE=mysql57-centos-7
+  - INSTANCE=connectors-oracle-7
+  - INSTANCE=mysql56-oracle-7
+  - INSTANCE=mysql57-oracle-7
 
 # Don't `bundle install`
 install: echo "skip bundle install"

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,10 @@ group :kitchen_vagrant do
   gem 'kitchen-vagrant', '~> 0.19'
 end
 
+group :kitchen_dokken do
+  gem 'kitchen-dokken'
+end
+
 group :kitchen_inspec do
   gem 'kitchen-inspec'
 end

--- a/attributes/mysql-connectors-community.rb
+++ b/attributes/mysql-connectors-community.rb
@@ -19,7 +19,7 @@ when 'rhel'
     when 2016
       default['yum']['mysql-connectors-community']['baseurl'] = 'http://repo.mysql.com/yum/mysql-connectors-community/el/6/$basearch/'
     end
-  when 'redhat'
+  when 'redhat', 'oracle' # ~FC024
     case node['platform_version'].to_i
     when 5
       # Real Redhat identifies $releasever as 5Server and 6Server

--- a/attributes/mysql55-community.rb
+++ b/attributes/mysql55-community.rb
@@ -19,7 +19,7 @@ when 'rhel'
     when 2016
       default['yum']['mysql55-community']['baseurl'] = 'http://repo.mysql.com/yum/mysql-5.5-community/el/6/$basearch/'
     end
-  when 'redhat'
+  when 'redhat', 'oracle' # ~FC024
     case node['platform_version'].to_i
     when 5
       # Real Redhat identifies $releasever as 5Server and 6Server

--- a/attributes/mysql56-community.rb
+++ b/attributes/mysql56-community.rb
@@ -19,7 +19,7 @@ when 'rhel'
     when 2016
       default['yum']['mysql56-community']['baseurl'] = 'http://repo.mysql.com/yum/mysql-5.6-community/el/6/$basearch/'
     end
-  when 'redhat'
+  when 'redhat', 'oracle' # ~FC024
     case node['platform_version'].to_i
     when 5
       # Real Redhat identifies $releasever as 5Server and 6Server

--- a/attributes/mysql57-community.rb
+++ b/attributes/mysql57-community.rb
@@ -19,7 +19,7 @@ when 'rhel'
     when 2016
       default['yum']['mysql57-community']['baseurl'] = 'http://repo.mysql.com/yum/mysql-5.7-community/el/6/$basearch/'
     end
-  when 'redhat'
+  when 'redhat', 'oracle' # ~FC024
     case node['platform_version'].to_i
     when 5
       # Real Redhat identifies $releasever as 5Server and 6Server


### PR DESCRIPTION
### Description

On Oracle Linux the base URL includes "Server" just like "real" RHEL. I've modified the conditional to treat Oracle just like RHEL.

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD

I couldn't get the kitchen-dokken driver to work. I did run the kitchen tests using kitchen-vagrant and they passed, including Oracle Linux.

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
