### PR TITLE
Switched to MySQL managed GPG key to avoid conflicts

### DIFF
--- a/attributes/mysql55-community.rb
+++ b/attributes/mysql55-community.rb
@@ -1,5 +1,5 @@
 default['yum']['mysql55-community']['repositoryid'] = 'mysql55-community'
-default['yum']['mysql55-community']['gpgkey'] = 'https://raw.githubusercontent.com/chef-cookbooks/yum-mysql-community/master/files/mysql_pubkey.asc'
+default['yum']['mysql55-community']['gpgkey'] = 'http://repo.mysql.com/RPM-GPG-KEY-mysql'
 default['yum']['mysql55-community']['description'] = 'MySQL 5.5 Community Server'
 default['yum']['mysql55-community']['failovermethod'] = 'priority'
 default['yum']['mysql55-community']['gpgcheck'] = true

--- a/attributes/mysql56-community.rb
+++ b/attributes/mysql56-community.rb
@@ -1,5 +1,5 @@
 default['yum']['mysql56-community']['repositoryid'] = 'mysql56-community'
-default['yum']['mysql56-community']['gpgkey'] = 'https://raw.githubusercontent.com/chef-cookbooks/yum-mysql-community/master/files/mysql_pubkey.asc'
+default['yum']['mysql56-community']['gpgkey'] = 'http://repo.mysql.com/RPM-GPG-KEY-mysql'
 default['yum']['mysql56-community']['description'] = 'MySQL 5.6 Community Server'
 default['yum']['mysql56-community']['failovermethod'] = 'priority'
 default['yum']['mysql56-community']['gpgcheck'] = true

--- a/attributes/mysql57-community.rb
+++ b/attributes/mysql57-community.rb
@@ -1,5 +1,5 @@
 default['yum']['mysql57-community']['repositoryid'] = 'mysql57-community'
-default['yum']['mysql57-community']['gpgkey'] = 'https://raw.githubusercontent.com/chef-cookbooks/yum-mysql-community/master/files/mysql_pubkey.asc'
+default['yum']['mysql57-community']['gpgkey'] = 'http://repo.mysql.com/RPM-GPG-KEY-mysql'
 default['yum']['mysql57-community']['description'] = 'MySQL 5.7 Community Server'
 default['yum']['mysql57-community']['failovermethod'] = 'priority'
 default['yum']['mysql57-community']['gpgcheck'] = true


### PR DESCRIPTION
### Description

Moves the GPG key out of the cookbook and leverages the MySQL hosted version in order to minimize the risk that changes will break multiple versions of the cookbook.

### Issues Resolved
- #16 

### Check List

- [Y] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [N] New functionality includes testing. - *No new functionality*
- [N] New functionality has been documented in the README if applicable - *No new functionality*
- [Y] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
