### PR TITLE
[Release 4.1.0 BUGFIX] Do not set description as it does not exists in resources

### DIFF
--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -20,7 +20,7 @@
 
 resource_name 'yum_mysql_community_repo'
 
-description 'Configure yum repo for MySQL Community edition'
+description 'Configure yum repo for MySQL Community edition' if description
 
 property :version, String,
          default: '8.0',

--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -20,7 +20,7 @@
 
 resource_name 'yum_mysql_community_repo'
 
-description 'Configure yum repo for MySQL Community edition' if description
+description 'Configure yum repo for MySQL Community edition' if respond_to?(:description)
 
 property :version, String,
          default: '8.0',


### PR DESCRIPTION
At least in some versions of chef, description does not exists.
Call description only when available.

Will avoid errors such as:

```
NoMethodError
-------------
undefined method `description' for #<Class:0x00000006398720>

Cookbook Trace:
---------------
  /tmp/kitchen/cache/cookbooks/yum-mysql-community/resources/repo.rb:23:in `class_from_file'

Relevant File Content:
----------------------
/tmp/kitchen/cache/cookbooks/yum-mysql-community/resources/repo.rb:

 16:  # distributed under the License is distributed on an "AS IS" BASIS,
 17:  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 18:  # See the License for the specific language governing permissions and
 19:  # limitations under the License.
 20:
 21:  resource_name 'yum_mysql_community_repo'
 22:
 23>> description 'Configure yum repo for MySQL Community edition'
```

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
