### PR TITLE
fix: update default GPG key to RPM-GPG-KEY-mysql-2025

### DIFF
--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -33,7 +33,7 @@ property :gpgcheck, [true, false],
          description: 'Enable or disable GPG checks'
 
 property :gpgkey, [String, Array],
-         default: 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2023',
+         default: 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2025',
          description: 'GPG key(s)'
 
 property :mysql_community_server, [true, false],


### PR DESCRIPTION
## Description

The default GPG key RPM-GPG-KEY-mysql-2023 expired on **2025-10-22T17:26:50Z**.

AlmaLinux 10 (and other EL 10+ distros) use rpm-sequoia for GPG validation, which strictly rejects expired keys. This causes GPG check FAILED when installing mysql-community-server via dnf.

MySQL has published a renewed key at RPM-GPG-KEY-mysql-2025 with the same fingerprint (BCA43417C3B485DD128EC6D4B7B3B788A8D3785C) and extended expiry.

## Changes

- Update default gpgkey property from RPM-GPG-KEY-mysql-2023 to RPM-GPG-KEY-mysql-2025 in resources/repo.rb

## References

- [MySQL Bug #119212](https://bugs.mysql.com/bug.php?id=119212) - Expired GPG signature key for package repository
- Key URL: https://repo.mysql.com/RPM-GPG-KEY-mysql-2025