### PR TITLE
ci: grant reusable workflow permissions

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -9,6 +9,10 @@ name: conventional-commits
       - edited
       - synchronize
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   conventional-commits:
     uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@6.0.0

--- a/.github/workflows/prevent-file-change.yml
+++ b/.github/workflows/prevent-file-change.yml
@@ -9,6 +9,10 @@ name: prevent-file-change
       - edited
       - synchronize
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   prevent-file-change:
     uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@6.0.0


### PR DESCRIPTION
## Summary
- grant pull request permissions to the conventional commits reusable workflow caller
- grant pull request write permissions to the prevent-file-change reusable workflow caller

## Verification
- yamllint .github/workflows/conventional-commits.yml .github/workflows/prevent-file-change.yml
- actionlint .github/workflows/conventional-commits.yml .github/workflows/prevent-file-change.yml