### PR TITLE
chore: migrate to Policyfile

### DIFF
--- a/chefignore
+++ b/chefignore
@@ -95,7 +95,6 @@ Gemfile.lock
 
 # Policyfile #
 ##############
-Policyfile.rb
 Policyfile.lock.json
 
 # Documentation #

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -10,6 +10,7 @@ transport:
 
 provisioner:
   name: dokken
+  policyfile: Policyfile.rb
 
 platforms:
   - name: almalinux-8

--- a/kitchen.exec.yml
+++ b/kitchen.exec.yml
@@ -9,3 +9,4 @@ provisioner:
   name: chef_infra
   chef_omnibus_install: false
   sudo: true
+  policyfile: Policyfile.rb

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -10,6 +10,7 @@ provisioner:
   multiple_converge: <%= ENV['MULTIPLE_CONVERGE'] || 2 %>
   deprecations_as_errors: true
   log_level: <%= ENV['CHEF_LOG_LEVEL'] || 'auto' %>
+  policyfile: Policyfile.rb
 
 verifier:
   name: inspec

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -16,6 +16,7 @@ provisioner:
   enforce_idempotency: <%= ENV['ENFORCE_IDEMPOTENCY'] || true %>
   multiple_converge: <%= ENV['MULTIPLE_CONVERGE'] || 2 %>
   deprecations_as_errors: true
+  policyfile: Policyfile.rb
 
 verifier:
   name: inspec
@@ -34,16 +35,6 @@ platforms:
   - name: rockylinux-9
   - name: rockylinux-10
 
-x-run_lists:
-  default: &default_run_list
-    - recipe[test::default]
-  mysql80: &mysql80_run_list
-    - recipe[test::mysql80]
-  connectors: &connectors_run_list
-    - recipe[test::connectors]
-  innovation: &innovation_run_list
-    - recipe[test::innovation]
-
 x-verifiers:
   default: &default_verifier
     inspec_tests:
@@ -60,13 +51,13 @@ x-verifiers:
 
 suites:
   - name: default
-    run_list: *default_run_list
+    provisioner:
+      named_run_list: default
     verifier: *default_verifier
 
   - name: mysql80
     provisioner:
       named_run_list: mysql80
-    run_list: *mysql80_run_list
     verifier: *mysql80_verifier
     excludes:
       - almalinux-10
@@ -77,11 +68,9 @@ suites:
   - name: connectors
     provisioner:
       named_run_list: connectors
-    run_list: *connectors_run_list
     verifier: *connectors_verifier
 
   - name: innovation
     provisioner:
       named_run_list: innovation
-    run_list: *innovation_run_list
     verifier: *innovation_verifier


### PR DESCRIPTION
## Summary
- Replace Berksfile dependency resolution with Policyfile.rb
- Update ChefSpec and Kitchen to use Policyfile resolution
- Update Copilot setup for chef install Policyfile.rb

## Verification
- chef install Policyfile.rb (worker run; local retry later hit approval timeout)
- cookstyle --no-server --cache-root /private/tmp/rubocop_cache
- markdownlint-cli2 "**/*.md"
- embedded rspec --format progress
- git diff --check
- kitchen list
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list